### PR TITLE
Use \StdSerializable no createWebhook

### DIFF
--- a/src/BancoInter.php
+++ b/src/BancoInter.php
@@ -608,7 +608,7 @@ class BancoInter
     {
         $url = "/cobranca/v2/boletos/webhook";
 
-        $params = new \stdClass();
+        $params = new \ctodobom\APInterPHP\StdSerializable();
 
         $params->webhookUrl = $webhookUrl;
 


### PR DESCRIPTION
Ocorre um erro no php pois espera essa class como interface, mudei e rodou.